### PR TITLE
Allow firestore project ID to be configured

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,16 @@
 
 A very early tool for tracking test flakiness.
 
+## Configuration
+
+### Environment Variables
+
+| Name                 | Value                                            |
+| -------------------- | ------------------------------------------------ |
+| `FIRESTORE_PROJECT_ID` | The GCP/Firebase project ID to use for Firestore |
+
+## Development
+
 ### Running the Tests
 
 First, start a firestore emulator:

--- a/charts/flake-reporter/Chart.yaml
+++ b/charts/flake-reporter/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: A tool for detecting and reporting on Flaky Tests
 name: flake-reporter
-version: 0.0.1
+version: 0.0.2
 appVersion: 0.0.1
 home: https://github.com/PlayerData/flake-reporter
 sources:

--- a/charts/flake-reporter/templates/deployment.yaml
+++ b/charts/flake-reporter/templates/deployment.yaml
@@ -26,10 +26,11 @@ spec:
             {{- toYaml . | nindent 12 }}
           {{- end }}
 
-          {{- with .Values.extraEnvVars }}
           env:
-            {{- toYaml . | nindent 12 }}
-          {{- end }}
+            - name: FIRESTORE_PROJECT_ID
+              value: {{ .Values.firestoreProjectId }}
+
+            {{- toYaml .Values.extraEnvVars | nindent 12 }}
         {{- toYaml .Values.sidecars | nindent 8 }}
       {{- if .Values.affinity }}
       affinity:

--- a/charts/flake-reporter/values.yaml
+++ b/charts/flake-reporter/values.yaml
@@ -1,3 +1,6 @@
+# The GCP project ID to use for firestore
+firestoreProjectId: test-project
+
 # Number of replicas to run
 replicaCount: 2
 

--- a/main.go
+++ b/main.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"log"
 	nethttp "net/http"
+	"os"
 
 	"cloud.google.com/go/firestore"
 	"github.com/gorilla/mux"
@@ -13,7 +14,11 @@ import (
 func main() {
 	ctx := context.Background()
 
-	firestoreClient, err := firestore.NewClient(ctx, "test-project")
+	firestoreProject := os.Getenv("FIRESTORE_PROJECT_ID")
+	if firestoreProject == "" {
+		log.Fatalf("FIRESTORE_PROJECT_ID unset")
+	}
+	firestoreClient, err := firestore.NewClient(ctx, firestoreProject)
 	if err != nil {
 		log.Fatalf("firebase.NewClient err: %v", err)
 	}


### PR DESCRIPTION
For deployment, the firestore project ID needs to be configurable.