### PR TITLE
Allow GCP workload identity service account to be set

### DIFF
--- a/charts/flake-reporter/Chart.yaml
+++ b/charts/flake-reporter/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: A tool for detecting and reporting on Flaky Tests
 name: flake-reporter
-version: 0.0.2
+version: 0.0.3
 appVersion: 0.0.1
 home: https://github.com/PlayerData/flake-reporter
 sources:

--- a/charts/flake-reporter/templates/service-account.yaml
+++ b/charts/flake-reporter/templates/service-account.yaml
@@ -4,6 +4,10 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ .Values.serviceAccount.name }}
+  annotations:
+    {{ if .Values.serviceAccount.gcpServiceAccount }}
+    iam.gke.io/gcp-service-account: {{ .Values.serviceAccount.gcpServiceAccount }}
+    {{ end }}
   labels:
     {{- include "flakeReporter.labels" . | nindent 4 }}
 {{- end }}

--- a/charts/flake-reporter/values.yaml
+++ b/charts/flake-reporter/values.yaml
@@ -30,6 +30,10 @@ serviceAccount:
   create: true
   name: flake-reporter
 
+  # If using GCP workload identity, sets the Google Service Account to be used
+  # See https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity
+  # gcpServiceAccount: flake-reporter@project-id.iam.gserviceaccount.com
+
 # A list of sidecar containers. Used to run firestore emulator for chart testing
 sidecars: []
 


### PR DESCRIPTION
See https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity