### PR TITLE
Correctly pass project name through to firestore document

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -6,7 +6,8 @@
   "configurations": [
     {
       "env": {
-        "FIRESTORE_EMULATOR_HOST": "localhost:8080"
+        "FIRESTORE_EMULATOR_HOST": "localhost:8080",
+        "FIRESTORE_PROJECT_ID": "test-project"
       },
       "name": "Launch Package",
       "type": "go",

--- a/internal/http/junit_handler_test.go
+++ b/internal/http/junit_handler_test.go
@@ -73,7 +73,7 @@ func TestUpdateTestSummary(t *testing.T) {
 	uploadTestResult(t, firestoreClient, ctx, "junit-success.xml")
 
 	err := firestoreClient.RunTransaction(ctx, func(ctx context.Context, tx *firestore.Transaction) error {
-		summary, err := models.ReadBranchSummary(firestoreClient, tx, "Session Tags", "Session Tags can create a session tag", "master")
+		summary, err := models.ReadBranchSummary(firestoreClient, tx, "test-project", "Session Tags", "Session Tags can create a session tag", "master")
 		if err != nil {
 			t.Error(err)
 			return err

--- a/internal/http/test_summary_handler.go
+++ b/internal/http/test_summary_handler.go
@@ -17,12 +17,14 @@ type TestSummaryHandler struct {
 
 func (handler *TestSummaryHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
-	testName := vars["test"]
+	projectName := vars["project"]
 	suiteName := vars["suite"]
+	testName := vars["test"]
 
 	payload := models.TestSummary{
-		Test:  testName,
-		Suite: suiteName,
+		Project: projectName,
+		Suite:   suiteName,
+		Test:    testName,
 	}
 
 	payload.PopulateFlakiness(handler.Client, handler.Ctx)

--- a/internal/http/test_summary_handler_test.go
+++ b/internal/http/test_summary_handler_test.go
@@ -21,10 +21,10 @@ func TestTestSummaryHandler(t *testing.T) {
 	mainSummary := models.BranchResultSummary{Results: []int{1, 1, 1, 0, 1}}
 	featureBranchSummary := models.BranchResultSummary{Results: []int{0, 0, 0, 0, 1}}
 
-	docRef := models.SummaryDocRef(firestoreClient, "test-suite", "example test", "main")
+	docRef := models.SummaryDocRef(firestoreClient, "test-project", "test-suite", "example test", "main")
 	docRef.Set(ctx, mainSummary)
 
-	docRef = models.SummaryDocRef(firestoreClient, "test-suite", "example test", "feature-branch")
+	docRef = models.SummaryDocRef(firestoreClient, "test-project", "test-suite", "example test", "feature-branch")
 	_, err := docRef.Set(ctx, featureBranchSummary)
 	if err != nil {
 		t.Fatal(err)
@@ -50,6 +50,7 @@ func TestTestSummaryHandler(t *testing.T) {
 	json.Unmarshal(res.Body.Bytes(), &responsePayload)
 
 	expectedPayload := models.TestSummary{
+		Project:   "test-project",
 		Suite:     "test-suite",
 		Test:      "example test",
 		Flakiness: 0.5,

--- a/internal/models/branch_result_summary.go
+++ b/internal/models/branch_result_summary.go
@@ -33,13 +33,13 @@ func (summary *BranchResultSummary) flakiness() float32 {
 	return 1.0 - passRate
 }
 
-func SummaryDocRef(client *firestore.Client, suite string, test string, branch string) *firestore.DocumentRef {
-	return testCollection(client, suite, test).Doc(branch)
+func SummaryDocRef(client *firestore.Client, project string, suite string, test string, branch string) *firestore.DocumentRef {
+	return testCollection(client, project, suite, test).Doc(branch)
 }
 
-func ReadBranchSummary(client *firestore.Client, tx *firestore.Transaction, suite string, test string, branch string) (BranchResultSummary, error) {
+func ReadBranchSummary(client *firestore.Client, tx *firestore.Transaction, project string, suite string, test string, branch string) (BranchResultSummary, error) {
 	var summary BranchResultSummary
-	docRef := SummaryDocRef(client, suite, test, branch)
+	docRef := SummaryDocRef(client, project, suite, test, branch)
 
 	doc, err := tx.Get(docRef)
 	if err != nil {
@@ -64,9 +64,9 @@ func resultInt(testResult junit.Test) int {
 
 func UpdateBranchSummary(client *firestore.Client, ctx context.Context, project string, suite string, branch string, testResult junit.Test) error {
 	err := client.RunTransaction(ctx, func(ctx context.Context, tx *firestore.Transaction) error {
-		docRef := SummaryDocRef(client, suite, testResult.Name, branch)
+		docRef := SummaryDocRef(client, project, suite, testResult.Name, branch)
 
-		summary, err := ReadBranchSummary(client, tx, suite, testResult.Name, branch)
+		summary, err := ReadBranchSummary(client, tx, project, suite, testResult.Name, branch)
 		if err != nil && status.Code(err) != codes.NotFound {
 			return err
 		}

--- a/internal/models/test_summary.go
+++ b/internal/models/test_summary.go
@@ -8,19 +8,20 @@ import (
 )
 
 type TestSummary struct {
+	Project       string
 	Suite         string
 	Test          string
 	BranchSummary []BranchResultSummary `json:"-"`
 	Flakiness     float32
 }
 
-func testCollection(client *firestore.Client, suite string, test string) *firestore.CollectionRef {
-	collectionPath := fmt.Sprintf("projects/test-project/suites/%s/%s", suite, test)
+func testCollection(client *firestore.Client, project string, suite string, test string) *firestore.CollectionRef {
+	collectionPath := fmt.Sprintf("projects/%s/suites/%s/%s", project, suite, test)
 	return client.Collection(collectionPath)
 }
 
 func (summary *TestSummary) populateBranchResults(client *firestore.Client, ctx context.Context) error {
-	collectionRef := testCollection(client, summary.Suite, summary.Test)
+	collectionRef := testCollection(client, summary.Project, summary.Suite, summary.Test)
 	branchResultSummaryRefs := collectionRef.Documents(ctx)
 
 	branchDocuments, err := branchResultSummaryRefs.GetAll()

--- a/internal/models/test_summary_test.go
+++ b/internal/models/test_summary_test.go
@@ -16,13 +16,13 @@ func TestSummaryPopulateBranchResults(t *testing.T) {
 	mainSummary := BranchResultSummary{Results: []int{1, 1, 1, 0, 1}}
 	featureBranchSummary := BranchResultSummary{Results: []int{1, 1, 1, 0, 1}}
 
-	docRef := SummaryDocRef(firestoreClient, "test-suite", "example test", "main")
+	docRef := SummaryDocRef(firestoreClient, "test-project", "test-suite", "example test", "main")
 	docRef.Set(ctx, mainSummary)
 
-	docRef = SummaryDocRef(firestoreClient, "test-suite", "example test", "feature-branch")
+	docRef = SummaryDocRef(firestoreClient, "test-project", "test-suite", "example test", "feature-branch")
 	docRef.Set(ctx, featureBranchSummary)
 
-	summary := TestSummary{Suite: "test-suite", Test: "example test"}
+	summary := TestSummary{Project: "test-project", Suite: "test-suite", Test: "example test"}
 
 	err := summary.populateBranchResults(firestoreClient, ctx)
 	if err != nil {

--- a/internal/test/test_helpers.go
+++ b/internal/test/test_helpers.go
@@ -2,8 +2,10 @@ package test
 
 import (
 	"context"
+	"fmt"
 	"log"
 	"net/http"
+	"os"
 	"testing"
 
 	"cloud.google.com/go/firestore"
@@ -19,7 +21,8 @@ func NewFirestoreTestClient(ctx context.Context) *firestore.Client {
 }
 
 func ClearFirestore(t *testing.T) {
-	req, err := http.NewRequest("DELETE", "http://localhost:8080/emulator/v1/projects/test-project/databases/(default)/documents", nil)
+	emulatorHost := os.Getenv("FIRESTORE_EMULATOR_HOST")
+	req, err := http.NewRequest("DELETE", fmt.Sprintf("http://%s/emulator/v1/projects/test-project/databases/(default)/documents", emulatorHost), nil)
 	if err != nil {
 		t.Fatal(err)
 


### PR DESCRIPTION
The `project` form field was previously ignored, when it shouldn't have been.