### PR TITLE
Report ingested results

### DIFF
--- a/internal/http/junit_handler.go
+++ b/internal/http/junit_handler.go
@@ -53,6 +53,8 @@ func (handler *JUnitHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	fmt.Fprintf(w, "%s\n", "Ingesting test results:")
+
 	for _, suite := range suites {
 		for _, test := range suite.Tests {
 			err = models.UpdateBranchSummary(handler.Client, handler.Ctx, project, suite.Name, branch, test)
@@ -61,8 +63,9 @@ func (handler *JUnitHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 				fmt.Fprintf(w, "%s", err)
 				return
 			}
+			fmt.Fprintf(w, "%s - %s\n", suite.Name, test.Name)
 		}
 	}
 
-	w.WriteHeader(http.StatusNoContent)
+	w.WriteHeader(http.StatusOK)
 }

--- a/internal/http/junit_handler_test.go
+++ b/internal/http/junit_handler_test.go
@@ -56,9 +56,19 @@ func uploadTestResult(t *testing.T, firestoreClient *firestore.Client, ctx conte
 	handler := http.Handler(&JUnitHandler{Client: firestoreClient, Ctx: ctx})
 	handler.ServeHTTP(res, req)
 
-	if status := res.Code; status != http.StatusNoContent {
+	if status := res.Code; status != http.StatusOK {
 		t.Errorf("handler returned wrong status code: got %v", status)
 		t.Fatalf("reponse body: got %s", res.Body.String())
+	}
+
+	expectedBody := `Ingesting test results:
+Session Tags - Session Tags can create a session tag
+Session Tags - Session Tags can update a session tag
+Session Tags - Session Tags can destroy a session tag
+`
+
+	if res.Body.String() != expectedBody {
+		t.Fatalf("response body incorrect: got %s", res.Body.String())
 	}
 }
 


### PR DESCRIPTION
To assist with debugging, report the ingested suite and test names in the HTTP response.