### PR TITLE
fix: Exclude chart version from label

### DIFF
--- a/charts/flake-reporter/Chart.yaml
+++ b/charts/flake-reporter/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: A tool for detecting and reporting on Flaky Tests
 name: flake-reporter
-version: 0.0.9
+version: 0.0.10
 appVersion: 0.0.1
 home: https://github.com/PlayerData/flake-reporter
 sources:

--- a/charts/flake-reporter/templates/_helpers.tpl
+++ b/charts/flake-reporter/templates/_helpers.tpl
@@ -2,6 +2,5 @@
 app.kubernetes.io/instance: "{{.Release.Name}}"
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 app.kubernetes.io/name: flake-reporter
-app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 helm.sh/chart: "{{.Chart.Name}}-{{.Chart.Version}}"
 {{- end }}


### PR DESCRIPTION
Prevents issues on upgrading as deployment.matchLabels is immutable